### PR TITLE
Add server timeout from cli

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -24,9 +24,9 @@ var opts struct {
 	Listen      string        `short:"l" long:"listen" env:"LISTEN" default:"localhost:8080" description:"listen on host:port"`
 	SecretKey   string        `short:"k" long:"key" env:"KEY" required:"true" description:"secret key"`
 	Batch       bool          `short:"b" long:"batch" description:"batch mode for multi-line scripts"`
-	Limit       int           `long:"limit"  default:"10" description:"limit how many concurrent update can be running"`
-	TimeOut     time.Duration `long:"timeout"  default:"1m" description:"for how long update task can be running"`
-	UpdateDelay time.Duration `long:"update-delay"  default:"1s" description:"delay between updates"`
+	Limit       int           `long:"limit" default:"10" description:"limit how many concurrent update can be running"`
+	TimeOut     time.Duration `long:"timeout" default:"1m" description:"for how long batch update task can be running"`
+	UpdateDelay time.Duration `long:"update-delay" default:"1s" description:"delay between updates"`
 	Dbg         bool          `long:"dbg" env:"DEBUG" description:"show debug info"`
 }
 
@@ -72,6 +72,7 @@ func main() {
 		Config:      conf,
 		Runner:      runner,
 		UpdateDelay: opts.UpdateDelay,
+		Timeout:     opts.TimeOut,
 	}
 
 	if err := srv.Run(ctx); err != nil {

--- a/app/server/server.go
+++ b/app/server/server.go
@@ -26,6 +26,7 @@ type Rest struct {
 	Config      Config
 	Runner      Runner
 	UpdateDelay time.Duration
+	Timeout     time.Duration
 }
 
 // Config declares command loader from config for given tasks
@@ -46,7 +47,7 @@ func (s *Rest) Run(ctx context.Context) error {
 		Addr:              s.Listen,
 		Handler:           s.router(),
 		ReadHeaderTimeout: time.Second,
-		WriteTimeout:      30 * time.Second,
+		WriteTimeout:      s.Timeout + 10*time.Second, // Give enough time to finish the task and respond
 		IdleTimeout:       time.Second,
 		ErrorLog:          log.ToStdLogger(log.Default(), "WARN"),
 	}


### PR DESCRIPTION
Resolves #22

Manually tested. Before:
```
time curl -v http://localhost:8080/update/test-sleep-40/super-secret-password
* Host localhost:8080 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8080...
* Connected to localhost (::1) port 8080
> GET /update/test-sleep-40/super-secret-password HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/8.6.0
> Accept: */*
>
* Empty reply from server
* Closing connection
curl: (52) Empty reply from server
curl -v http://localhost:8080/update/test-sleep-40/super-secret-password  0.01s user 0.01s system 0% cpu 41.033 total
```

After:
```
time curl -v http://localhost:8080/update/test-sleep-40/super-secret-password
* Host localhost:8080 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8080...
* Connected to localhost (::1) port 8080
> GET /update/test-sleep-40/super-secret-password HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/1.1 200 OK
< App-Name: updater
< App-Version: add-timeout-test-eda6fd1-20240804T12:47:24
< Author: umputun
< Content-Type: application/json; charset=utf-8
< Ratelimit-Limit: 10
< Ratelimit-Remaining: 9
< Ratelimit-Reset: 1
< X-Rate-Limit-Duration: 1
< X-Rate-Limit-Limit: 10.00
< X-Rate-Limit-Request-Remote-Addr: 192.168.65.1:25656
< Date: Sun, 04 Aug 2024 17:48:09 GMT
< Content-Length: 40
<
{"task":"test-sleep-40","updated":"ok"}
* Connection #0 to host localhost left intact
curl -v http://localhost:8080/update/test-sleep-40/super-secret-password  0.01s user 0.01s system 0% cpu 41.041 total```